### PR TITLE
refactor: change damage property in sword config to float

### DIFF
--- a/appFabric/1.20.1/src/main/java/net/kenddie/fantasyweapons/config/FWConfig.java
+++ b/appFabric/1.20.1/src/main/java/net/kenddie/fantasyweapons/config/FWConfig.java
@@ -27,7 +27,7 @@ public class FWConfig {
     @Configuration
     public static class SwordConfig {
         public static final SwordConfig DEFAULT = new SwordConfig();
-        public int damage = 3;
+        public float damage = 3;
         public float speed = -2.4f;
     }
 }

--- a/appFabric/1.20.1/src/main/java/net/kenddie/fantasyweapons/item/weapon/lib/FWWeaponBasicSwordItem.java
+++ b/appFabric/1.20.1/src/main/java/net/kenddie/fantasyweapons/item/weapon/lib/FWWeaponBasicSwordItem.java
@@ -1,12 +1,37 @@
 package net.kenddie.fantasyweapons.item.weapon.lib;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.item.Tier;
+import org.jetbrains.annotations.NotNull;
 
 public class FWWeaponBasicSwordItem extends SwordItem {
 
-    public FWWeaponBasicSwordItem(Tier tier, int damage, float speed, Item.Properties properties) {
-        super(tier, damage, speed, properties);
+    private final float attackDamage;
+    private final Multimap<Attribute, AttributeModifier> defaultModifiers;
+
+    public FWWeaponBasicSwordItem(Tier tier, float damage, float speed, Item.Properties properties) {
+        super(tier, (int) damage, speed, properties);
+        this.attackDamage = damage;
+        ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
+        builder.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", this.attackDamage, AttributeModifier.Operation.ADDITION));
+        builder.put(Attributes.ATTACK_SPEED, new AttributeModifier(BASE_ATTACK_SPEED_UUID, "Weapon modifier", speed, AttributeModifier.Operation.ADDITION));
+        this.defaultModifiers = builder.build();
+    }
+
+    @Override
+    public float getDamage() {
+        return attackDamage;
+    }
+
+    @Override
+    public @NotNull Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot equipmentSlot) {
+        return equipmentSlot == EquipmentSlot.MAINHAND ? this.defaultModifiers : super.getDefaultAttributeModifiers(equipmentSlot);
     }
 }

--- a/appForge/1.20.1/src/main/java/net/kenddie/fantasyweapons/config/FWConfig.java
+++ b/appForge/1.20.1/src/main/java/net/kenddie/fantasyweapons/config/FWConfig.java
@@ -30,7 +30,7 @@ public class FWConfig {
     @Configuration
     public static class SwordConfig {
         public static final SwordConfig DEFAULT = new SwordConfig();
-        public int damage = 3;
+        public float damage = 3;
         public float speed = -2.4f;
     }
 }

--- a/appForge/1.20.1/src/main/java/net/kenddie/fantasyweapons/item/weapon/lib/FWWeaponBasicSwordItem.java
+++ b/appForge/1.20.1/src/main/java/net/kenddie/fantasyweapons/item/weapon/lib/FWWeaponBasicSwordItem.java
@@ -1,11 +1,37 @@
 package net.kenddie.fantasyweapons.item.weapon.lib;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.SwordItem;
 import net.minecraft.world.item.Tier;
+import org.jetbrains.annotations.NotNull;
 
 public class FWWeaponBasicSwordItem extends SwordItem {
 
-    public FWWeaponBasicSwordItem(Tier tier, int damage, float speed, Properties properties) {
-        super(tier, damage, speed, properties);
+    private final float attackDamage;
+    private final Multimap<Attribute, AttributeModifier> defaultModifiers;
+
+    public FWWeaponBasicSwordItem(Tier tier, float damage, float speed, Item.Properties properties) {
+        super(tier, (int) damage, speed, properties);
+        this.attackDamage = damage;
+        ImmutableMultimap.Builder<Attribute, AttributeModifier> builder = ImmutableMultimap.builder();
+        builder.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(BASE_ATTACK_DAMAGE_UUID, "Weapon modifier", this.attackDamage, AttributeModifier.Operation.ADDITION));
+        builder.put(Attributes.ATTACK_SPEED, new AttributeModifier(BASE_ATTACK_SPEED_UUID, "Weapon modifier", speed, AttributeModifier.Operation.ADDITION));
+        this.defaultModifiers = builder.build();
+    }
+
+    @Override
+    public float getDamage() {
+        return attackDamage;
+    }
+
+    @Override
+    public @NotNull Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(@NotNull EquipmentSlot equipmentSlot) {
+        return equipmentSlot == EquipmentSlot.MAINHAND ? this.defaultModifiers : super.getDefaultAttributeModifiers(equipmentSlot);
     }
 }


### PR DESCRIPTION
This commit changes the damage property in sword config to float, as well as adds some tweaks to the FWWeaponBasicSwordItem to be able to assign floats as damage values (which is unsupported by the parent SwordItem).